### PR TITLE
[Zendesk#724] Client changes

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -6,6 +6,8 @@
 	<description><![CDATA[Salesfire is a service that provides a number of tools that help to increase sales using various on site methods.]]></description>
 	<author><![CDATA[Salesfire]]></author>
 	<tab><![CDATA[smart_shopping]]></tab>
+	<confirmUninstall><![CDATA[Are you sure you want to uninstall Salesfire]]></confirmUninstall>
 	<is_configurable>1</is_configurable>
-	<need_instance>1</need_instance>
+	<need_instance>0</need_instance>
+	<limited_countries></limited_countries>
 </module>

--- a/salesfire.php
+++ b/salesfire.php
@@ -175,8 +175,8 @@ class Salesfire extends Module
     protected function getConfigFormValues()
     {
         return array(
-            'SALESFIRE_ACTIVE' => Configuration::get('SALESFIRE_ACTIVE', true),
-            'SALESFIRE_SITE_ID' => Configuration::get('SALESFIRE_SITE_ID', null),
+            'SALESFIRE_ACTIVE' => Configuration::get('SALESFIRE_ACTIVE'),
+            'SALESFIRE_SITE_ID' => Configuration::get('SALESFIRE_SITE_ID'),
         );
     }
 
@@ -208,6 +208,10 @@ class Salesfire extends Module
      */
     public function hookHeader()
     {
+        if (!Configuration::get('SALESFIRE_ACTIVE')) {
+            return;
+        }
+
         $smarty_variables = array(
             'sfSiteId' => Tools::safeOutput(Configuration::get('SALESFIRE_SITE_ID')),
         );
@@ -235,6 +239,10 @@ class Salesfire extends Module
 
     public function hookOrderConfirmation($params)
     {
+        if (!Configuration::get('SALESFIRE_ACTIVE')) {
+            return;
+        }
+
         $order = $params['order'];
         $currency = Currency::getCurrencyInstance((int) $order->id_currency);
 


### PR DESCRIPTION
Within their changes had a config_gb.xml with those values but I just merged those into the config file. https://devdocs.prestashop.com/1.7/modules/creation/module-file-structure/

> need_instance indicates whether an instance of the module must be created when it is displayed in the module list. This can be useful if the module has to perform checks on the PrestaShop configuration, and display warning message accordingly.

 
Their other changes make sense, don't do anything if it's not enabled and making it disabled by default.